### PR TITLE
build: update dockerhub destination

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -30,7 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: cockroachlabs/sql_efficiency_check
+          images: cockroachdb/sql_efficiency_check
           labels: |
             org.opencontainers.image.title=SQL Efficiency Check
             org.opencontainers.image.vendor=Cockroach Labs Inc.


### PR DESCRIPTION
Fixing config to use hub.docker.com/repository/docker/cockroachdb/
for builds (which we use for both cockroachlabs and cockroachdb
github repositories).